### PR TITLE
Bug fix for enum properties in case of Inline mapping for graphFetch …

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/graphFetch/tests/testGraphFetchEmbdded.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/graphFetch/tests/testGraphFetchEmbdded.pure
@@ -43,6 +43,33 @@ function <<test.Test, test.AlloyOnly>> {serverVersion.start='v1_19_0'} meta::rel
    );
 }
 
+
+function <<test.Test, test.AlloyOnly>> {serverVersion.start='v1_19_0'} meta::relational::graphFetch::tests::embedded::testEmbeddedMappingForPropertyHavingEnumAttribute(): Boolean[1]
+{
+   let tree = #{
+      Person {
+         firstName,
+         firm {
+            legalName
+         },
+         address{
+          type
+         }
+      }
+   }#;
+   let query = {|Person.all()->graphFetch($tree)->serialize($tree)};
+   let mapping = meta::relational::tests::mapping::embedded::model::mapping::testMappingEmbeddedWithFirmDistinct;
+   let runtime = meta::external::store::relational::tests::testRuntime();
+
+   let result = execute($query, $mapping, $runtime, meta::relational::extension::relationalExtensions()).values;
+
+   assertJsonStringsEqual(
+      '[{"firstName":"Peter","firm":{"legalName":"Firm X"},"address":{"type":"CITY"}},{"firstName":"John","firm":{"legalName":"Firm X"},"address":{"type":"CITY"}},{"firstName":"Fabrice","firm":{"legalName":"Firm A"},"address":{"type":"REGION"}}]',
+      $result
+   );
+}
+
+
 function <<test.Test, test.AlloyOnly>> {serverVersion.start='v1_19_0'} meta::relational::graphFetch::tests::embedded::testMultiLevelEmbeddedMapping(): Boolean[1]
 {
    let tree = #{

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/graphFetch/tests/testGraphFetchEmbeddedInline.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/graphFetch/tests/testGraphFetchEmbeddedInline.pure
@@ -47,6 +47,29 @@ function <<test.Test, test.AlloyOnly>> {serverVersion.start='v1_19_0'} meta::rel
   );
 }
 
+function <<test.Test, test.AlloyOnly>> {serverVersion.start='v1_19_0'} meta::relational::graphFetch::tests::embedded::inline::testInlineEmbeddedMappingForPropertyHavingEnumAttribute(): Boolean[1]
+{
+  let tree = #{
+    Product {
+      name,
+      bondDetails {
+        description,
+        status
+      }
+    }
+  }#;
+  let query = {|Product.all()->graphFetch($tree)->serialize($tree)};
+  let mapping = meta::relational::tests::mapping::embedded::advanced::mapping::testMappingEmbedded;
+  let runtime =  meta::external::store::relational::tests::testRuntime();
+  let result = execute($query, $mapping, $runtime, meta::relational::extension::relationalExtensions()).values;
+  assertJsonStringsEqual(
+    '[{"name":"Product 1","bondDetails":{"description":"Bond 1","status":"Open"}},' +
+    '{"name":"Product 2","bondDetails":{"description":"Bond 2","status":"Open"}},' +
+    '{"name":"Product 3","bondDetails":{"description":"SuperBond 3 super","status":"Closed"}}]',
+    $result
+  );
+}
+
 function <<test.Test, test.AlloyOnly>> {serverVersion.start='v1_19_0'} meta::relational::graphFetch::tests::embedded::inline::testQualifierWithArgs(): Boolean[1]
 {
   let tree = #{

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/mapping/embedded/testInlineEmbeddedMapping.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/mapping/embedded/testInlineEmbeddedMapping.pure
@@ -385,7 +385,8 @@ Mapping meta::relational::tests::mapping::embedded::advanced::mapping::testMappi
       scope([eDB]PRODUCT_DENORM)
       (
          description:BOND_DETAILS,
-         type: BOND_TYPE
+         type: BOND_TYPE,
+         status: EnumerationMapping bondStatusMapping: BOND_STATUS 
       )
    }
 
@@ -393,6 +394,13 @@ Mapping meta::relational::tests::mapping::embedded::advanced::mapping::testMappi
    {
       type : [eDB]BondClassificationTable.type
    }
+
+   meta::relational::tests::mapping::embedded::advanced::model::Status: EnumerationMapping bondStatusMapping
+  {
+    Pending: ['Pending'],
+    Open: ['Open'],
+    Closed: ['Closed']
+  }
 
 )
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-javaPlatformBinding-pure/src/main/resources/core_relational_java_platform_binding/legendJavaPlatformBinding/executionPlanNodes/graphFetch/graphFetchRelational.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-javaPlatformBinding-pure/src/main/resources/core_relational_java_platform_binding/legendJavaPlatformBinding/executionPlanNodes/graphFetch/graphFetchRelational.pure
@@ -448,7 +448,7 @@ function <<access.private>> meta::relational::executionPlan::platformBinding::le
                                           {|
                                              if ($propertyType->instanceOf(meta::pure::metamodel::type::Enumeration),
                                                 {|
-                                                   let allPropertyMappings = $sets->at($s)->cast(@InstanceSetImplementation)->allPropertyMappings()->filter(pm | $pm.property->instanceOf(Property) && $pm.property->functionReturnType().rawType->toOne()->instanceOf(meta::pure::metamodel::type::DataType));
+                                                   let allPropertyMappings = $sets->at($s)->meta::relational::mapping::dataTypePropertyMappings()->filter(pm | $pm.property->instanceOf(Property) && $pm.property->functionReturnType().rawType->toOne()->instanceOf(meta::pure::metamodel::type::DataType));
                                                    let currentPropertyMapping = $allPropertyMappings->filter(x | $x.property == $prop)->toOne()->cast(@RelationalPropertyMapping);
                                                    $enumPropertyGetterCodes->eval($prop, $propertyType, $currentPropertyMapping);
                                                 },


### PR DESCRIPTION
#### What type of PR is this?
- Bug Fix

#### What does this PR do / why is it needed ?
Bug fix for enum properties in case of Inline mapping for graphFetch flow. Incase of enum properties for Inline graphFetch flow we are not able to fetch property mappings. This PR is intended to fix that.